### PR TITLE
Remove alpha view and source image view from superview when completed

### DIFF
--- a/Pod/Classes/RMPZoomTransitionAnimator.m
+++ b/Pod/Classes/RMPZoomTransitionAnimator.m
@@ -91,6 +91,10 @@ static const NSTimeInterval kBackwardCompleteAnimationDuration = 0.18;
                                                                                 animatingSourceImageView:sourceImageView];
                                                   }
                                                   [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+                                                  
+                                                  // Remove the views from superviews to release the references
+                                                  [alphaView removeFromSuperview];
+                                                  [sourceImageView removeFromSuperview];
                                               }];
                          }];
         
@@ -117,6 +121,10 @@ static const NSTimeInterval kBackwardCompleteAnimationDuration = 0.18;
                                                                                 animatingSourceImageView:sourceImageView];
                                                   }
                                                   [transitionContext completeTransition:![transitionContext transitionWasCancelled]];
+                                                  
+                                                  // Remove the views from superviews to release the references
+                                                  [alphaView removeFromSuperview];
+                                                  [sourceImageView removeFromSuperview];
                                               }];
                          }];
     }


### PR DESCRIPTION
There was a bug that the source image view and alpha view will stay in the view hierarchy after animations. Just fixed that.
