### PR TITLE
Call required {begin|end}AppearanceTransition handlers on source view controller

### DIFF
--- a/Pod/Classes/RMPZoomTransitionAnimator.m
+++ b/Pod/Classes/RMPZoomTransitionAnimator.m
@@ -104,6 +104,9 @@
     [containerView addSubview:sourceImageView];
     
     if (self.goingForward) {
+        
+        [fromVC beginAppearanceTransition:NO animated:YES];
+        
         [UIView animateWithDuration:kForwardAnimationDuration
                               delay:0
                             options:UIViewAnimationOptionCurveEaseOut
@@ -133,6 +136,8 @@
                                                   // Remove the views from superviews to release the references
                                                   [alphaView removeFromSuperview];
                                                   [sourceImageView removeFromSuperview];
+                                                  
+                                                  [fromVC endAppearanceTransition];
                                               }];
                          }];
         


### PR DESCRIPTION
If you don't do this, iOS will not call the appropriate view{Will|Did}Disappear methods during your custom transition.